### PR TITLE
#23: Set up a basic CLI tool for connecting to Mango replicaset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.slf4j:slf4j-api:2.0.13'
 
+    implementation 'info.picocli:picocli:4.7.6'
+    annotationProcessor 'info.picocli:picocli-codegen:4.7.6'
+
     implementation 'ch.qos.logback:logback-classic:1.5.6'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
@@ -28,5 +31,6 @@ test {
 }
 
 application {
-    mainClass = 'store.net.MangoDBServer'
+    mainClass = 'MangoApp'
+    applicationDefaultJvmArgs = ['-Xmx2g']
 }

--- a/src/main/java/MangoApp.java
+++ b/src/main/java/MangoApp.java
@@ -1,4 +1,3 @@
-import server.CommandProcessor;
 import server.MangoServer;
 
 import java.io.IOException;

--- a/src/main/java/cli/MangoCLI.java
+++ b/src/main/java/cli/MangoCLI.java
@@ -1,0 +1,78 @@
+package cli;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+@Command(
+        name = "mango",
+        mixinStandardHelpOptions = true,
+        version = "mango 1.0",
+        description = "Command line interface for MangoDB",
+        subcommands = {
+                MangoCLI.StartCommand.class
+        }
+)
+public class MangoCLI implements Callable<Integer> {
+
+    @Command(
+            name="start",
+            description = "Start MangoDB resources"
+    )
+    static class StartCommand implements Callable<Integer> {
+        // a subclass which handles specific commands
+        @Command(
+                name="replicaset",
+                description = "Start a replicaset"
+        )
+        int startReplicaSet(
+                @Parameters(index= "0", description = "The unique name for this replicaset deployment")
+                String replicaSetName,
+                @Option(names = {"-f", "--file"}, required = true, description = "The configuration file for this replicaset")
+                File configFile
+        ) {
+            System.out.printf(">>> Starting replica set '%s' using config '%s'...\n",
+                    replicaSetName, configFile.getAbsolutePath());
+
+            if (!configFile.exists()) {
+                System.err.printf("Config file not found");
+            }
+
+            return 0;
+        }
+
+        @Override
+        public Integer call() throws Exception {
+            System.out.println("Please provide which resource to start");
+            return 0;
+        }
+    }
+
+    public static void main(String[] args) {
+        final String RESET = "\u001B[0m";
+        final String PASTEL_YELLOW = "\u001B[38;2;255;223;0m";
+
+        final String banner = """
+                ███╗   ███╗ █████╗ ███╗   ██╗ ██████╗  ██████╗ ██████╗ ██████╗\s
+                ████╗ ████║██╔══██╗████╗  ██║██╔════╝ ██╔═══██╗██╔══██╗██╔══██╗
+                ██╔████╔██║███████║██╔██╗ ██║██║  ███╗██║   ██║██║  ██║██████╔╝
+                ██║╚██╔╝██║██╔══██║██║╚██╗██║██║   ██║██║   ██║██║  ██║██╔══██╗
+                ██║ ╚═╝ ██║██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██████╔╝██████╔╝
+                ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚═════╝ ╚═════╝\s 
+                """ ;
+
+        System.out.println(PASTEL_YELLOW + banner + RESET);
+
+        int exitCode = new CommandLine(new MangoCLI()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return 0;
+    }
+}

--- a/src/main/java/storage/mem/UnsafeMemStore.java
+++ b/src/main/java/storage/mem/UnsafeMemStore.java
@@ -18,7 +18,7 @@ public class UnsafeMemStore implements MemStore {
     // not thread safe, but fast
     private static Logger logger = LoggerFactory.getLogger(UnsafeMemStore.class);
     private String DATA_PATH;
-    final ConcurrentHashMap<String, MemRecord> keyDir = new ConcurrentHashMap<>();
+    final HashMap<String, MemRecord> keyDir = new HashMap<>();
 
     public UnsafeMemStore() {
         DATA_PATH = new ConfigManager("config.properties").getProperty("datapath");


### PR DESCRIPTION
resolves #23 

Set up a basic CLI tool using picocli. Will implement the commands after setting up other components like MangoTree and ReplicationManager. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line interface (CLI) for managing MangoDB resources, including support for starting replica sets with configuration file validation and help/version options.

- **Chores**
  - Updated build configuration to include the Picocli library and set a default maximum heap size for the application.
  - Changed the main application entry point to MangoApp.

- **Refactor**
  - Modified internal data structures in memory storage for improved performance (non-thread-safe usage).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->