### PR TITLE
#25: Set up MangoTree to register and route PUT commands

### DIFF
--- a/src/main/java/MangoApp.java
+++ b/src/main/java/MangoApp.java
@@ -14,8 +14,16 @@ public class MangoApp {
                 ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚═════╝ ╚═════╝\s 
                 """ ;
         System.out.println(banner);
-        
-        final MangoServer mangoServer = new MangoServer();
-        mangoServer.start();
+
+        if (args.length == 2) {
+            int port = Integer.parseInt(args[0]);
+            String role = args[1];
+
+            final MangoServer mangoServer = new MangoServer(role, port);
+            mangoServer.start();
+        } else {
+            final MangoServer mangoServer = new MangoServer();
+            mangoServer.start();
+        }
     }
 }

--- a/src/main/java/client/MangoClient.java
+++ b/src/main/java/client/MangoClient.java
@@ -11,13 +11,17 @@ public class MangoClient implements AutoCloseable {
     private final String host;
     private final int port;
     private Socket socket;
-    private boolean connected = false;
-    private BufferedReader in;
-    private PrintWriter out;
+    protected boolean connected = false;
+    protected BufferedReader in;
+    protected PrintWriter out;
 
     public MangoClient(final String host, final int port) {
         this.host = host;
         this.port = port;
+    }
+
+    public String getId() {
+       return host + ":" + port;
     }
 
     public void connect() {

--- a/src/main/java/client/MangoTreeClient.java
+++ b/src/main/java/client/MangoTreeClient.java
@@ -1,0 +1,51 @@
+package client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class MangoTreeClient extends MangoClient {
+    public MangoTreeClient(final String host, final int port) {
+        super(host, port);
+    }
+
+    public List<ServerAddress> getSecondaryAddresses() throws IOException {
+        final List<ServerAddress> result = new ArrayList<>();
+        try {
+            if (!connected) {
+                connect();
+            }
+        } catch (final RuntimeException e) {
+            System.out.println("Unable to ");
+        }
+
+        out.println("SECONDARIES");
+        out.flush();
+        String response = in.readLine();
+
+        System.out.println("Response: " + response);
+
+        if (Objects.equals(response, "")) {
+            return result;
+        }
+
+        if (response.contains("ERROR")) {
+            throw new IOException(response);
+        }
+
+        // a single line containing list of hosts and ports
+        List<String> splits = List.of(response.split(" "));
+
+        if (splits.size() % 2 != 0) {
+            throw new IOException("Invalid response from server: " + response);
+        }
+
+        for (int i = 0 ; i < splits.size() - 1; i += 2) {
+           result.add(new ServerAddress(splits.get(i), Integer.parseInt(splits.get(i + 1))));
+        }
+
+        return result;
+    }
+}
+

--- a/src/main/java/client/ServerAddress.java
+++ b/src/main/java/client/ServerAddress.java
@@ -1,0 +1,3 @@
+package client;
+
+public record ServerAddress(String host, int port) {}

--- a/src/main/java/commands/CommandParser.java
+++ b/src/main/java/commands/CommandParser.java
@@ -14,6 +14,7 @@ import static commands.CommandType.HEARTBEAT;
 import static commands.CommandType.HELP;
 import static commands.CommandType.PUT;
 import static commands.CommandType.REGISTER;
+import static commands.CommandType.SECONDARIES;
 import static commands.CommandType.STATUS;
 import static legacy.engine.LogWriter.FLUSH_TOMBSTONE_VALUE;
 import static legacy.engine.LogWriter.TOMBSTONE_VALUE;
@@ -53,7 +54,12 @@ public class CommandParser {
             case HELP -> handleHelp(argsString);
             case HEARTBEAT -> handleHeartbeat(argsString);
             case REGISTER -> handleRegister(argsString);
+            case SECONDARIES -> handleSecondaries(argsString);
         };
+    }
+
+    private static Command handleSecondaries(final String argsString) {
+        return new Command(SECONDARIES, null);
     }
 
     private static Command handleRegister(final String argsString) {

--- a/src/main/java/commands/CommandParser.java
+++ b/src/main/java/commands/CommandParser.java
@@ -10,8 +10,10 @@ import static commands.CommandType.DELETE;
 import static commands.CommandType.EXISTS;
 import static commands.CommandType.FLUSH;
 import static commands.CommandType.GET;
+import static commands.CommandType.HEARTBEAT;
 import static commands.CommandType.HELP;
 import static commands.CommandType.PUT;
+import static commands.CommandType.REGISTER;
 import static commands.CommandType.STATUS;
 import static legacy.engine.LogWriter.FLUSH_TOMBSTONE_VALUE;
 import static legacy.engine.LogWriter.TOMBSTONE_VALUE;
@@ -49,7 +51,23 @@ public class CommandParser {
             case EXISTS -> handleExists(argsString);
             case STATUS -> handleStatus(argsString);
             case HELP -> handleHelp(argsString);
+            case HEARTBEAT -> handleHeartbeat(argsString);
+            case REGISTER -> handleRegister(argsString);
         };
+    }
+
+    private static Command handleRegister(final String argsString) {
+        String[] args = argsString.strip().split(SPACE_DELIMITER);
+
+        if (args.length < REGISTER.getParameterCount() || args.length > REGISTER.getParameterCount()) {
+            throw new InvalidParametersException(REGISTER.getErrorMessage());
+        }
+
+        return new Command(REGISTER, args);
+    }
+
+    private static Command handleHeartbeat(final String argsString) {
+        return new Command(HEARTBEAT, null);
     }
 
     private static Command handleHelp(final String argsString) {

--- a/src/main/java/commands/CommandType.java
+++ b/src/main/java/commands/CommandType.java
@@ -9,7 +9,8 @@ public enum CommandType {
     STATUS(0, "STATUS expects no parameters"),
     HELP(0, "HELP expects no parameters"),
     HEARTBEAT(2, "ERROR: Usage: HEARTBEAT <HOST> <PORT>"),
-    REGISTER(3, "ERROR: Usage: REGISTER <PRIMARY|SECONDARY> <HOST> <PORT>");
+    REGISTER(3, "ERROR: Usage: REGISTER <PRIMARY|SECONDARY> <HOST> <PORT>"),
+    SECONDARIES(0, "");
 
     private final int parameterCount;
     private final String errorMessage;

--- a/src/main/java/commands/CommandType.java
+++ b/src/main/java/commands/CommandType.java
@@ -7,7 +7,9 @@ public enum CommandType {
     EXISTS(1, "EXISTS expects a key"),
     FLUSH(0, "FLUSH expects no parameters"),
     STATUS(0, "STATUS expects no parameters"),
-    HELP(0, "HELP expects no parameters");
+    HELP(0, "HELP expects no parameters"),
+    HEARTBEAT(2, "ERROR: Usage: HEARTBEAT <HOST> <PORT>"),
+    REGISTER(3, "ERROR: Usage: REGISTER <PRIMARY|SECONDARY> <HOST> <PORT>");
 
     private final int parameterCount;
     private final String errorMessage;

--- a/src/main/java/replication/ReplicationManager.java
+++ b/src/main/java/replication/ReplicationManager.java
@@ -1,0 +1,103 @@
+package replication;
+
+import client.MangoClient;
+import client.MangoTreeClient;
+import client.ServerAddress;
+import storage.AsyncWriteRequest;
+import storage.disk.WriteRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+public class ReplicationManager {
+
+    private final List<MangoClient> secondaryMangoClients;
+    private final MangoTreeClient treeClient;
+    private final Thread replicationThread;
+    private final BlockingQueue<WriteRequest> replicationQueue;
+    private final Set<String> secondaryIds;
+
+    public ReplicationManager() {
+        // this shouldn't be hardcoded
+        this.treeClient = new MangoTreeClient("localhost", 9090);
+        treeClient.connect();
+
+        System.out.println("ReplicationManager successfully connected to MangoTree");
+        this.secondaryIds = new HashSet<>();
+        this.secondaryMangoClients = new ArrayList<>();
+        refreshSecondaryClients();
+
+        this.replicationQueue = new ArrayBlockingQueue<>(1000);
+
+        this.replicationThread = new Thread(this::replicateToSecondaries);
+        this.replicationThread.start();
+    }
+
+    public void asyncReplicate(final String key, final String value) {
+        final WriteRequest writeRequest = new WriteRequest(key, value, System.currentTimeMillis());
+        replicationQueue.add(writeRequest);
+    }
+
+    public void replicateToSecondaries() {
+        while (!Thread.currentThread().isInterrupted()) {
+           if (!replicationQueue.isEmpty()) {
+               final WriteRequest request = replicationQueue.poll();
+
+               try {
+                   if (secondaryMangoClients.isEmpty()) {
+                       System.out.println("No secondary clients available for replication; refreshing...");
+                       refreshSecondaryClients();
+                   }
+
+                   for (final MangoClient secondaryClient : secondaryMangoClients) {
+                       secondaryClient.put(request.key(), request.value());
+                   }
+               } catch (final Exception e) {
+                   System.err.println("Failed to replicate to secondary: " + e.getMessage());
+                   // refresh secondary clients and retry
+                   refreshSecondaryClients();
+                   replicationQueue.add(request); // push back to queue
+               }
+           }
+        }
+    }
+
+    private void refreshSecondaryClients() {
+        try {
+            final List<ServerAddress> latestSecondaries = treeClient.getSecondaryAddresses();
+            List<MangoClient> newSecondaryClients = new ArrayList<>();
+            Set<String> potentiallyDeadSecondaries = new HashSet<>(secondaryIds);
+
+            for (final ServerAddress latestSecondary : latestSecondaries) {
+                final String id = String.format("%s:%d", latestSecondary.host(), latestSecondary.port());
+
+                if (!secondaryIds.contains(id)) {
+                    final MangoClient secondaryClient = new MangoClient(latestSecondary.host(), latestSecondary.port());
+                    secondaryClient.connect();
+                    newSecondaryClients.add(secondaryClient);
+                    secondaryIds.add(id);
+                } else {
+                    // if it's still there, it's not dead
+                    potentiallyDeadSecondaries.remove(id);
+                }
+            }
+
+            for (final MangoClient secondaryClient : secondaryMangoClients) {
+                if (potentiallyDeadSecondaries.contains(secondaryClient.getId())) {
+                    secondaryMangoClients.remove(secondaryClient);
+                    secondaryIds.remove(secondaryClient.getId());
+                }
+            }
+
+            secondaryMangoClients.addAll(newSecondaryClients);
+        } catch (IOException e) {
+            System.err.println("Failed to refresh secondary clients: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/server/MangoServer.java
+++ b/src/main/java/server/MangoServer.java
@@ -3,6 +3,7 @@ package server;
 import config.ConfigManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tree.ServerRole;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -42,6 +43,20 @@ public class MangoServer {
         registerShutdownHook();
     }
 
+    public MangoServer(final String role, final int port) throws IOException {
+        this.port = port;
+
+        ConfigManager manager = new ConfigManager("config.properties");
+
+        threadCount = manager.getIntProperty("server.threads", 1);
+        this.threadPool = Executors.newFixedThreadPool(threadCount);
+
+        this.orderedResponse = manager.getBooleanProperty("ordered.response", false);
+
+        this.commandProcessor = new CommandProcessor(ServerRole.valueOf(role.toUpperCase()));
+        registerShutdownHook();
+    }
+
     private void registerShutdownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             logger.info("Shutdown hook triggered!");
@@ -69,6 +84,7 @@ public class MangoServer {
         logger.info("MangoServer starting...");
         logger.info("Server thread count: {}", threadCount);
         logger.info("Ordered response: {}", orderedResponse);
+        logger.info("Role: {}", commandProcessor.getRole());
         runServer();
     }
 

--- a/src/main/java/tree/MangoTree.java
+++ b/src/main/java/tree/MangoTree.java
@@ -1,0 +1,237 @@
+package tree;
+
+import client.MangoClient;
+import commands.Command;
+import commands.CommandParser;
+import commands.CommandType;
+
+import javax.print.attribute.standard.RequestingUserName;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static server.CommandProcessor.WRAP_GREEN;
+import static server.CommandProcessor.WRAP_RED;
+
+enum ServerStatus {
+   ALIVE,
+   DEAD,
+   UNKNOWN;
+}
+
+enum ServerRole {
+    PRIMARY,
+    SECONDARY,
+    STANDALONE
+}
+
+
+class ServerInfo {
+    private String host;
+    private int port;
+    private ServerStatus status;
+    private ServerRole role;
+    private MangoClient client;
+
+    public ServerInfo(
+           final String host,
+           final int port,
+           final ServerRole role
+    ) {
+        this.host = host;
+        this.port = port;
+        this.role = role;
+        this.status = ServerStatus.ALIVE;
+        this.client = new MangoClient(host, port);
+
+        client.connect();
+    }
+
+    public MangoClient getClient() {
+        return client;
+    }
+}
+
+public class MangoTree {
+    private static String treebanner = """
+             __  __                       _____             \s
+            |  \\/  | __ _ _ __   __ _  __|_   _| __ ___  ___\s
+            | |\\/| |/ _` | '_ \\ / _` |/ _ \\| || '__/ _ \\/ _ \\
+            | |  | | (_| | | | | (_| | (_) | || | |  __/  __/
+            |_|  |_|\\__,_|_| |_|\\__, |\\___/|_||_|  \\___|\\___|
+                                |___/                       \s
+         """;
+    private int port;
+    private ExecutorService healthCheckExecutor;
+    private ExecutorService connectionExecutor;
+    private HashMap<String, ServerInfo> registeredServers;
+    private String primaryServerId;
+
+    private List<CommandType> PRIMARY_COMMANDS = List.of(
+            CommandType.PUT,
+            CommandType.DELETE
+    );
+
+    private List<CommandType> SECONDARY_COMMANDS = List.of(
+            CommandType.GET
+    );
+
+    private List<CommandType> TREE_COMMANDS = List.of(
+            CommandType.REGISTER,
+            CommandType.HEARTBEAT
+    );
+
+    public MangoTree(int port) {
+        this.port = port;
+        this.connectionExecutor = Executors.newCachedThreadPool();
+        this.healthCheckExecutor = Executors.newSingleThreadExecutor();
+        this.registeredServers = new HashMap<>();
+    }
+
+    public void start() {
+        System.out.println("Starting Mango tree server on port " + port);
+
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            // if thread gets interrupted, stop everything
+            // it will get interrupted during shutdown
+            // but when does it really happen? we'll find out
+            while (!Thread.currentThread().isInterrupted()) {
+                final Socket socketClient = serverSocket.accept();
+                connectionExecutor.submit(() -> handleClientConnection(socketClient));
+            }
+        } catch (IOException e) {
+            System.err.println("Error serving socket connections: " + e.getMessage());
+            throw new RuntimeException(e);
+        } finally {
+            stop();
+        }
+    }
+
+    private void handleClientConnection(final Socket clientSocket) {
+       System.out.println("Handling client connection from " + clientSocket.getRemoteSocketAddress());
+       try(
+           BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+           PrintWriter out = new PrintWriter(clientSocket.getOutputStream(), true);
+       ) {
+           String line;
+           out.print(treebanner);
+           out.flush();
+           while ((line = in.readLine()) != null) {;
+               String response = processCommand(line);
+               System.out.println("Received: " + line);
+               out.println(response);
+           }
+       } catch (Exception e) {
+           System.err.println("Error handling client connection: " + e.getMessage());
+           throw new RuntimeException(e);
+       } finally {
+           try {
+               System.out.println("Closing client connection from " + clientSocket.getRemoteSocketAddress());
+               clientSocket.close();
+           } catch (IOException e) {
+               // ignore
+           }
+       }
+    }
+
+    private String processCommand(final String line) {
+        final Command command = CommandParser.parse(line);
+
+        assert command != null;
+        if (PRIMARY_COMMANDS.contains(command.type())) {
+            // send message to primary
+            // if it's not there, say primary not registered
+
+            if (primaryServerId == null) {
+                return String.format(WRAP_RED, "PRIMARY NOT REGISTERED");
+            }
+
+            ServerInfo primaryServer = registeredServers.get(primaryServerId);
+            final String response = sendCommandToServer(primaryServer, command);
+            System.out.println("Response from primary: " + response);
+
+            return response;
+        }
+
+        if (command.type().equals(CommandType.REGISTER)) {
+            System.out.println("Registering command: " + command);
+            String role = command.args()[0];
+            Integer port = Integer.valueOf(command.args()[1]);
+            String host = command.args()[2];
+
+            try {
+                handleRegistration(role, port, host);
+            } catch (final Exception e) {
+                System.err.println("Error registering command: " + e.getMessage());
+                return String.format(WRAP_RED, "ERROR REGISTERING: " + e.getMessage());
+            }
+        }
+
+        return String.format(WRAP_GREEN, "SUCCESSFULLY REGISTERED");
+    }
+
+    private String sendCommandToServer(final ServerInfo server, final Command command) {
+        String response = "MISTAKE";
+        try {
+            if (command.type().equals(CommandType.PUT)) {
+                String key = command.args()[0];
+                String value = command.args()[1];
+
+                server.getClient().put(key, value);
+                response = String.format(WRAP_GREEN, "PUT SUCCESSFUL");
+            } else if (command.type().equals(CommandType.GET)) {
+                String key = command.args()[0];
+                response = server.getClient().get(key);
+            }
+
+        } catch (final IOException e) {
+            System.err.println("Error sending command: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+
+        return response;
+    }
+
+    private void handleRegistration(final String roleStr, final Integer port, final String host) {
+        ServerRole role = ServerRole.valueOf(roleStr.toUpperCase());
+        String serverId =  String.format("%s:%d", role, port);
+
+        if (role == ServerRole.PRIMARY) {
+            if (primaryServerId != null && primaryServerId != serverId) {
+                throw new RuntimeException("There's already a primary server registered");
+            }
+        }
+
+        System.out.println("Registering " + role + " at " + host + ":" + port);
+
+        if (registeredServers.containsKey(serverId)) {
+            System.out.println("Server already registered");
+        } else {
+            registeredServers.put(serverId, new ServerInfo(host, port, role));
+            if (role == ServerRole.PRIMARY) {
+                primaryServerId = serverId;
+            }
+        }
+
+        System.out.println("Registered " + role + " at " + host + ":" + port);
+    }
+
+    public void stop() {
+        // stop health check executor
+        // stop connection executor
+    }
+
+    public static void main(String [] args) {
+        int port = 9090;
+        MangoTree tree = new MangoTree(port);
+        tree.start();
+    }
+}
+

--- a/src/main/java/tree/ServerRole.java
+++ b/src/main/java/tree/ServerRole.java
@@ -1,0 +1,7 @@
+package tree;
+
+public enum ServerRole {
+    PRIMARY,
+    SECONDARY,
+    STANDALONE
+}

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,4 +1,4 @@
-port=8080
+port=8082
 datapath=./data/
 server.threads=500
 storage.type=single


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new server application for managing a cluster of Mango servers, supporting PRIMARY, SECONDARY, and STANDALONE roles.
  - Added support for registering servers and handling heartbeat commands to monitor server status.
  - Enhanced command handling to route operations and enforce a single PRIMARY server registration.
  - Added asynchronous replication of write requests from PRIMARY to SECONDARY servers.
  - Introduced client support to query secondary server addresses dynamically.
  - Enabled server startup configuration with role and port parameters.
- **Improvements**
  - Improved error messages and usage instructions for new commands.
  - Added color-coded responses for success and error messages in client interactions.
  - Enhanced command processing with replication awareness based on server role.
  - Updated default server port configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->