### PR TITLE
Implement DELETE

### DIFF
--- a/src/main/java/server/CommandProcessor.java
+++ b/src/main/java/server/CommandProcessor.java
@@ -80,6 +80,8 @@ public class CommandProcessor {
             return switch (command.type()) {
                 case PUT -> handlePut(command.args());
                 case GET -> handleGet(command.args());
+                case DELETE -> handleDelete(command.args());
+
                 default ->
                     CompletableFuture.completedFuture(String.format(WRAP_RED, "ERROR: " + RESPONSE_INVALID_INPUT));
             };
@@ -92,7 +94,7 @@ public class CommandProcessor {
         final CompletableFuture<Void> responseFuture = storageEngine.write(args[0], args[1]);
 
         return responseFuture.thenApply(voidResult -> {
-            if (serverRole == ServerRole.PRIMARY && replicationManager != null) {
+            if (serverRole == ServerRole.PRIMARY) {
                 replicationManager.asyncReplicate(args[0], args[1]);
             }
 
@@ -114,6 +116,14 @@ public class CommandProcessor {
             }
 
             return String.format(WRAP_YELLOW, value);
+        });
+    }
+
+    private CompletableFuture<String> handleDelete(final String[] args) {
+        final CompletableFuture<Void> deleteFuture = storageEngine.delete(args[0]);
+
+        return deleteFuture.thenApply(voidResult -> {
+            return String.format(WRAP_GREEN, "SUCCESS");
         });
     }
 }

--- a/src/main/java/storage/SingleThreadedStorageEngine.java
+++ b/src/main/java/storage/SingleThreadedStorageEngine.java
@@ -30,6 +30,7 @@ public class SingleThreadedStorageEngine implements StorageEngine {
     private static final Logger logger = LoggerFactory.getLogger(SingleThreadedStorageEngine.class);
     private static final int MAX_BATCH_SIZE = 1000;
     private static final int MAX_WRITE_CHANNEL_SIZE = 64 * 1024 * 1024; // 64 MB
+    private static final String TOMBSTONE_VALUE = "__TOMBSTONE__";
     private final DiskStore diskStore;
     private final MemStore memStore;
     private final String DATA_PATH;
@@ -84,7 +85,8 @@ public class SingleThreadedStorageEngine implements StorageEngine {
         }
 
         try {
-            final String value = diskStore.read(memRecord.get().valueOffset(), fileNamesToReadChannels.get(memRecord.get().filename()));
+            final String value = diskStore.read(memRecord.get().valueOffset(),
+                    fileNamesToReadChannels.get(memRecord.get().filename()));
             return CompletableFuture.completedFuture(value);
         } catch (final IOException e) {
             logger.error("Exception while reading request", e);
@@ -93,8 +95,18 @@ public class SingleThreadedStorageEngine implements StorageEngine {
     }
 
     @Override
-    public CompletableFuture<Void> delete(String key) {
-        return null;
+    public CompletableFuture<Void> delete(final String key) {
+        final Optional<MemRecord> memRecord = memStore.read(key);
+        if (memRecord.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        try {
+            return write(key, TOMBSTONE_VALUE);
+        } catch (final Exception e) {
+            logger.error("Exception while deleting key", e);
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -121,7 +133,13 @@ public class SingleThreadedStorageEngine implements StorageEngine {
 
                 for (int i = 0; i < writeResults.size(); i++) {
                     final AsyncWriteRequest batchItem = batch.get(i);
-                    memStore.write(batchItem.key(), writeResults.get(i).offset(), currentWriteFileName, writeResults.get(i).timestamp());
+
+                    if (!batchItem.value().equals(TOMBSTONE_VALUE)) {
+                        memStore.write(batchItem.key(), writeResults.get(i).offset(), currentWriteFileName,
+                                writeResults.get(i).timestamp());
+                    } else {
+                        memStore.delete(batchItem.key());
+                    }
 
                     // set value to null since the CompletableFuture is of void type
                     batchItem.future().complete(null);
@@ -193,13 +211,11 @@ public class SingleThreadedStorageEngine implements StorageEngine {
             writeChannel = FileChannel.open(
                     Path.of(DATA_PATH + currentWriteFileName),
                     StandardOpenOption.CREATE,
-                    StandardOpenOption.APPEND
-            );
+                    StandardOpenOption.APPEND);
 
             FileChannel currentReadFileChannel = FileChannel.open(
                     Path.of(DATA_PATH + currentWriteFileName),
-                    StandardOpenOption.READ
-            );
+                    StandardOpenOption.READ);
             fileNamesToReadChannels.put(currentWriteFileName, currentReadFileChannel);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -220,8 +236,7 @@ public class SingleThreadedStorageEngine implements StorageEngine {
         return FileChannel.open(
                 Path.of(DATA_PATH + currentWriteFileName),
                 StandardOpenOption.CREATE,
-                StandardOpenOption.APPEND
-        );
+                StandardOpenOption.APPEND);
     }
 
 }

--- a/src/main/java/storage/mem/MemStore.java
+++ b/src/main/java/storage/mem/MemStore.java
@@ -3,6 +3,10 @@ package storage.mem;
 import java.util.Optional;
 
 public interface MemStore {
-   void write(String key, long valueOffset, String filename, long timestamp);
-   Optional<MemRecord> read(String key);
+    void write(String key, long valueOffset, String filename, long timestamp);
+
+    Optional<MemRecord> read(String key);
+
+    // what should be the return type?
+    void delete(String key);
 }

--- a/src/main/java/storage/mem/UnsafeMemStore.java
+++ b/src/main/java/storage/mem/UnsafeMemStore.java
@@ -1,11 +1,17 @@
-package storage.mem; import config.ConfigManager;
-import org.slf4j.Logger; import org.slf4j.LoggerFactory; import storage.disk.DiskRecord;
+package storage.mem;
+
+import config.ConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import storage.disk.DiskRecord;
 
 import java.io.File;
-import java.io.IOException; import java.nio.channels.FileChannel;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections; import java.util.HashMap;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,8 +38,8 @@ public class UnsafeMemStore implements MemStore {
 
     @Override
     public void write(String key, long valueOffset, String filename, long timestamp) {
-       MemRecord memRecord = new MemRecord(valueOffset, filename, timestamp);
-       keyDir.put(key, memRecord);
+        MemRecord memRecord = new MemRecord(valueOffset, filename, timestamp);
+        keyDir.put(key, memRecord);
     }
 
     @Override
@@ -63,7 +69,7 @@ public class UnsafeMemStore implements MemStore {
         List<String> sortedFileNames = fileChannels.keySet().stream().sorted(Collections.reverseOrder()).toList();
         long latestFlushTimestamp = Long.MIN_VALUE;
 
-        for (final String filename: sortedFileNames) {
+        for (final String filename : sortedFileNames) {
             logger.info("Reading data file: {}", filename);
             long offset = 0;
             final FileChannel fileChannel = fileChannels.get(filename);
@@ -77,7 +83,8 @@ public class UnsafeMemStore implements MemStore {
 
                 if (record != null) {
                     if (record.value().equals(TOMBSTONE_VALUE)) {
-                        if (keyDir.containsKey(record.key()) && keyDir.get(record.key()).timestamp() < record.timestamp()) {
+                        if (keyDir.containsKey(record.key())
+                                && keyDir.get(record.key()).timestamp() < record.timestamp()) {
                             keyDir.remove(record.key());
                             offset = record.offset() + 2;
                             continue;
@@ -119,5 +126,19 @@ public class UnsafeMemStore implements MemStore {
         }
 
         logger.info("KeyDir constructed finished, size: {}\n", keyDir.size());
+    }
+
+    @Override
+    public void delete(final String key) {
+        if (!keyDir.containsKey(key)) {
+            return;
+        }
+
+        try {
+            keyDir.remove(key);
+        } catch (final Exception e) {
+            logger.error("Exception while deleting key", e);
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Wire DELETE through CommandProcessor and implement it in the single-threaded storage engine by writing a tombstone record (value = __TOMBSTONE__) and removing the key from the in-memory keyDir once the disk write completes. Add MemStore.delete to support that, and reuse the existing batch write loop — batches with a tombstone value go through memStore.delete instead of memStore.write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DELETE commands, enabling users to remove data from the system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrdlm/MangoDB/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->